### PR TITLE
Compatibility with ggplot2 4.0.0

### DIFF
--- a/R/plotDists.R
+++ b/R/plotDists.R
@@ -232,11 +232,17 @@ plotNormalInvGamma <- function(mu, lambda, alpha, beta) {
   inputs <- expand.grid(x, sig_sq)
   out <- dNormalInverseGamma(inputs$Var1, inputs$Var2, mu, lambda, alpha, beta)
   dat <- data.frame(x = inputs$Var1, sig_sq = inputs$Var2, res = out)
+  
+  level_mapping <- if (packageVersion("ggplot2") > "3.4.0") {
+    ggplot2::aes(fill = ggplot2::after_stat(.data[["level"]]))
+  } else {
+    ggplot2::aes_string(fill = "..level..")
+  }
 
-  p <- ggplot2::ggplot(dat, ggplot2::aes_string('x', 'sig_sq', z = 'res')) +
+  p <- ggplot2::ggplot(dat, ggplot2::aes(.data[['x']], .data[['sig_sq']], z = .data[['res']])) +
     ggplot2::ggtitle(paste0('Normal Inverse Gamma PDF for ',
                             paste0(c(mu, lambda, alpha, beta), collapse = ", "))) +
-    ggplot2::stat_contour(ggplot2::aes_string(fill = '..level..'), geom = "polygon", bins = 10) +
+    ggplot2::stat_contour(level_mapping, geom = "polygon", bins = 10) +
     ggplot2::scale_fill_continuous(name = 'Probability Density', position = 'bottom') +
     theme_bayesAB() +
     ggplot2::theme(legend.position = 'bottom')

--- a/R/plotDists.R
+++ b/R/plotDists.R
@@ -33,19 +33,19 @@ NULL
 plotDist_ <- function(support, hseq, dist, params) {
 
   discretes <- c('Poisson')
-
-  ribbon_or_bar <- ggplot2::geom_ribbon(ggplot2::aes(ymax = .data$hseq),
-                                        ymin = 0,
-                                        size = 2,
-                                        color = I("lightblue"),
-                                        fill = "lightgreen",
-                                        alpha = .25)
+  
+  args <- list(size = 2, color = I("lightblue"), fill = "lightgreen", alpha = .25)
+  if (packageVersion("ggplot2") > "3.4.0") {
+    names(args)[1] <- "linewidth"
+  }
+  
+  ribbon_or_bar <- do.call(
+    ggplot2::geom_ribbon, 
+    c(list(mapping = ggplot2::aes(ymax = .data$hseq), ymin = 0), args)
+  )
 
   if(dist %in% discretes) {
-    ribbon_or_bar <- ggplot2::geom_col(size = 2,
-                                       color = I("lightblue"),
-                                       fill = "lightgreen",
-                                       alpha = .25)
+    ribbon_or_bar <- do.call(ggplot2::geom_col, args)
     notEmpty <- hseq != 0
     support <- support[notEmpty]
     hseq <- hseq[notEmpty]

--- a/tests/testthat/test-dists.R
+++ b/tests/testthat/test-dists.R
@@ -19,18 +19,23 @@ test_that("Closure madness", {
 })
 
 test_that("Success", {
+  
+  get_labs <- function(x) x$labels
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    get_labs <- ggplot2::get_labs
+  }
 
-  expect_equal(plotPoisson(1)$labels$y, 'PDF')
-  expect_equal(plotPareto(1, 1)$labels$y, 'PDF')
-  expect_equal(plotNormal(1, 1)$labels$y, 'PDF')
-  expect_equal(plotGamma(1, 1)$labels$y, 'PDF')
-  expect_equal(plotBeta(1, 1)$labels$y, 'PDF')
-  expect_equal(plotInvGamma(1, 1)$labels$y, 'PDF')
-  expect_equal(plotLogNormal(1, 1)$labels$y, 'PDF')
+  expect_equal(get_labs(plotPoisson(1))$y, 'PDF')
+  expect_equal(get_labs(plotPareto(1, 1))$y, 'PDF')
+  expect_equal(get_labs(plotNormal(1, 1))$y, 'PDF')
+  expect_equal(get_labs(plotGamma(1, 1))$y, 'PDF')
+  expect_equal(get_labs(plotBeta(1, 1))$y, 'PDF')
+  expect_equal(get_labs(plotInvGamma(1, 1))$y, 'PDF')
+  expect_equal(get_labs(plotLogNormal(1, 1))$y, 'PDF')
   expect_equal(qinvgamma(1 - (.Machine$double.eps) / 2, 2, 2), Inf)
   expect_equal(dpareto(c(0, 1, 2), 1, 1), c(0, 0, .25))
   expect_equal(dpareto(c(5, 15), 20, 3), c(0, 0))
   expect_equal(max(plotNormalInvGamma(3, 100, 51, 216)$data$sig_sq), qgamma(.99, 51, 216) * 100)
-  expect_equal(plotNormalInvGamma(3, 1, 1, 1)$labels$y, 'sig_sq')
+  expect_equal(get_labs(plotNormalInvGamma(3, 1, 1, 1))$y, 'sig_sq')
 
 })


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the bayesAB package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
In addition, some deprecated functionality is avoided.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun